### PR TITLE
🚀 [Feature]: Signed JWTs can now be created with New-Jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,51 @@ Import-Module -Name Jwt
 
 ## Usage
 
-> [!NOTE]
-> This module is under active development. The placeholder function `New-Jwt` is available but not yet implemented.
+`New-Jwt` builds a signed JWT from a payload (and optional header overrides) and returns a typed
+`[Jwt]` object. Call `ToString()` for the compact `header.payload.signature` form used on the wire.
+
+Only `RS256` is supported in this release. Two signing methods are available:
+
+### Sign with a local RSA private key
 
 ```powershell
-New-Jwt
+$now = [System.DateTimeOffset]::UtcNow
+$jwt = New-Jwt `
+    -Header  @{ kid = 'my-key-id' } `
+    -Payload @{
+        iss = 'my-app'
+        iat = $now.ToUnixTimeSeconds()
+        exp = $now.AddMinutes(10).ToUnixTimeSeconds()
+    } `
+    -PrivateKey (Get-Content ./private-key.pem -Raw)
+
+$jwt.ToString()  # header.payload.signature
 ```
+
+The `-PrivateKey` parameter accepts either a PEM-encoded `[string]` or a `[securestring]`.
+
+### Sign with Azure Key Vault
+
+```powershell
+$jwt = New-Jwt `
+    -Payload @{ iss = 'my-app'; iat = $iat; exp = $exp } `
+    -KeyVaultKeyReference 'https://myvault.vault.azure.net/keys/my-key'
+```
+
+Key Vault signing calls the [Sign REST API](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/sign/sign)
+(`api-version=7.4`) and obtains a bearer token from the [Azure CLI](https://learn.microsoft.com/cli/azure/)
+or [Az PowerShell](https://learn.microsoft.com/powershell/azure/), whichever is available. Neither
+is declared as a module dependency — install and sign in with one of them before calling.
+
+### Public surface
+
+| Member | Kind     | Purpose                                                       |
+|--------|----------|---------------------------------------------------------------|
+| `New-Jwt`     | Function | Create and sign a JWT (RS256 via local key or Key Vault) |
+| `Jwt`         | Class    | Token object; `ToString()` returns `header.payload.signature` |
+| `JwtHeader`   | Class    | Typed JOSE header (`alg`, `typ`, `kid`, plus extension fields) |
+| `JwtPayload`  | Class    | Typed payload (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`, plus private claims) |
+| `JwtBase64Url`| Class    | Base64URL encoding utilities ([RFC 4648 §5](https://datatracker.ietf.org/doc/html/rfc4648#section-5)) |
 
 ## Documentation
 

--- a/src/classes/public/Jwt.ps1
+++ b/src/classes/public/Jwt.ps1
@@ -1,0 +1,33 @@
+﻿class Jwt {
+    [JwtHeader] $Header
+    [JwtPayload] $Payload
+    [string] $Signature
+    [string] $EncodedHeader
+    [string] $EncodedPayload
+
+    Jwt() {}
+
+    Jwt([JwtHeader] $Header, [JwtPayload] $Payload) {
+        $this.Header = $Header
+        $this.Payload = $Payload
+        $this.EncodedHeader = [JwtBase64Url]::Encode($Header.ToOrderedDictionary())
+        $this.EncodedPayload = [JwtBase64Url]::Encode($Payload.ToOrderedDictionary())
+        $this.Signature = ''
+    }
+
+    Jwt([JwtHeader] $Header, [JwtPayload] $Payload, [string] $Signature) {
+        $this.Header = $Header
+        $this.Payload = $Payload
+        $this.EncodedHeader = [JwtBase64Url]::Encode($Header.ToOrderedDictionary())
+        $this.EncodedPayload = [JwtBase64Url]::Encode($Payload.ToOrderedDictionary())
+        $this.Signature = $Signature
+    }
+
+    [string] SigningInput() {
+        return "$($this.EncodedHeader).$($this.EncodedPayload)"
+    }
+
+    [string] ToString() {
+        return "$($this.EncodedHeader).$($this.EncodedPayload).$($this.Signature)"
+    }
+}

--- a/src/classes/public/Jwt.ps1
+++ b/src/classes/public/Jwt.ps1
@@ -1,6 +1,9 @@
 ﻿class Jwt {
-    [JwtHeader] $Header
-    [JwtPayload] $Payload
+    # Property types are intentionally [object] so this class file can be parsed before its
+    # sibling class files (JwtHeader, JwtPayload) are loaded. Constructor parameters still
+    # enforce the concrete types.
+    [object] $Header
+    [object] $Payload
     [string] $Signature
     [string] $EncodedHeader
     [string] $EncodedPayload

--- a/src/classes/public/JwtBase64Url.ps1
+++ b/src/classes/public/JwtBase64Url.ps1
@@ -1,0 +1,17 @@
+﻿class JwtBase64Url {
+    static [string] Encode([byte[]] $Bytes) {
+        return [JwtBase64Url]::ConvertToBase64UrlFormat([System.Convert]::ToBase64String($Bytes))
+    }
+
+    static [string] Encode([string] $String) {
+        return [JwtBase64Url]::Encode([System.Text.Encoding]::UTF8.GetBytes($String))
+    }
+
+    static [string] Encode([System.Collections.IDictionary] $Data) {
+        return [JwtBase64Url]::Encode((ConvertTo-Json -InputObject $Data -Compress -Depth 100))
+    }
+
+    static [string] ConvertToBase64UrlFormat([string] $Base64String) {
+        return $Base64String.TrimEnd('=').Replace('+', '-').Replace('/', '_')
+    }
+}

--- a/src/classes/public/JwtHeader.ps1
+++ b/src/classes/public/JwtHeader.ps1
@@ -1,0 +1,30 @@
+﻿class JwtHeader {
+    [string] $alg
+    [string] $typ = 'JWT'
+    [string] $kid
+    [hashtable] $AdditionalFields = @{}
+
+    JwtHeader() {}
+
+    JwtHeader([System.Collections.IDictionary] $Data) {
+        foreach ($key in $Data.Keys) {
+            switch ($key) {
+                'alg' { $this.alg = [string]$Data[$key] }
+                'typ' { $this.typ = [string]$Data[$key] }
+                'kid' { $this.kid = [string]$Data[$key] }
+                default { $this.AdditionalFields[$key] = $Data[$key] }
+            }
+        }
+    }
+
+    [System.Collections.Specialized.OrderedDictionary] ToOrderedDictionary() {
+        $h = [ordered]@{}
+        if ($this.alg) { $h['alg'] = $this.alg }
+        if ($this.typ) { $h['typ'] = $this.typ }
+        if ($this.kid) { $h['kid'] = $this.kid }
+        foreach ($key in $this.AdditionalFields.Keys) {
+            if (-not $h.Contains($key)) { $h[$key] = $this.AdditionalFields[$key] }
+        }
+        return $h
+    }
+}

--- a/src/classes/public/JwtPayload.ps1
+++ b/src/classes/public/JwtPayload.ps1
@@ -1,0 +1,42 @@
+﻿class JwtPayload {
+    [string] $iss
+    [string] $sub
+    [object] $aud
+    [Nullable[long]] $exp
+    [Nullable[long]] $nbf
+    [Nullable[long]] $iat
+    [string] $jti
+    [hashtable] $AdditionalFields = @{}
+
+    JwtPayload() {}
+
+    JwtPayload([System.Collections.IDictionary] $Data) {
+        foreach ($key in $Data.Keys) {
+            switch ($key) {
+                'iss' { $this.iss = [string]$Data[$key] }
+                'sub' { $this.sub = [string]$Data[$key] }
+                'aud' { $this.aud = $Data[$key] }
+                'exp' { $this.exp = [long]$Data[$key] }
+                'nbf' { $this.nbf = [long]$Data[$key] }
+                'iat' { $this.iat = [long]$Data[$key] }
+                'jti' { $this.jti = [string]$Data[$key] }
+                default { $this.AdditionalFields[$key] = $Data[$key] }
+            }
+        }
+    }
+
+    [System.Collections.Specialized.OrderedDictionary] ToOrderedDictionary() {
+        $h = [ordered]@{}
+        if ($this.iss) { $h['iss'] = $this.iss }
+        if ($this.sub) { $h['sub'] = $this.sub }
+        if ($null -ne $this.aud) { $h['aud'] = $this.aud }
+        if ($this.exp.HasValue) { $h['exp'] = $this.exp.Value }
+        if ($this.nbf.HasValue) { $h['nbf'] = $this.nbf.Value }
+        if ($this.iat.HasValue) { $h['iat'] = $this.iat.Value }
+        if ($this.jti) { $h['jti'] = $this.jti }
+        foreach ($key in $this.AdditionalFields.Keys) {
+            if (-not $h.Contains($key)) { $h[$key] = $this.AdditionalFields[$key] }
+        }
+        return $h
+    }
+}

--- a/src/functions/private/Add-JwtKeyVaultSignature.ps1
+++ b/src/functions/private/Add-JwtKeyVaultSignature.ps1
@@ -1,0 +1,94 @@
+﻿function Add-JwtKeyVaultSignature {
+    <#
+        .SYNOPSIS
+        Signs a JWT using an RSA key stored in Azure Key Vault (RS256).
+
+        .DESCRIPTION
+        Computes the SHA-256 digest of the JWT signing input (header.payload), then calls the
+        Azure Key Vault Sign REST API (api-version=7.4) to produce an RS256 signature.
+        Authentication is obtained from the Azure CLI (`az`) or Az PowerShell (`Get-AzAccessToken`),
+        whichever is available. Neither is declared as a module dependency; one must be installed
+        and authenticated at call time.
+
+        .EXAMPLE
+        ```powershell
+        Add-JwtKeyVaultSignature -Jwt $unsigned -KeyVaultKeyReference 'https://myvault.vault.azure.net/keys/mykey'
+        ```
+
+        Signs the unsigned JWT using the specified Key Vault key.
+
+        .OUTPUTS
+        Jwt
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+        Justification = 'Required to pass the Key Vault access token to Invoke-RestMethod'
+    )]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Function mutates the in-memory [Jwt] object only'
+    )]
+    [CmdletBinding()]
+    [OutputType([Jwt])]
+    param(
+        # The unsigned [Jwt] object to sign.
+        [Parameter(Mandatory)]
+        [Jwt] $Jwt,
+
+        # The Azure Key Vault key URL used for signing
+        # (e.g. https://myvault.vault.azure.net/keys/mykey or .../keys/mykey/<version>).
+        [Parameter(Mandatory)]
+        [string] $KeyVaultKeyReference
+    )
+
+    process {
+        $azCli = Get-Command -Name 'az' -CommandType Application -ErrorAction SilentlyContinue
+        $azPs = Get-Command -Name 'Get-AzAccessToken' -ErrorAction SilentlyContinue
+
+        if ($azCli) {
+            try {
+                $accessToken = (& az account get-access-token --resource 'https://vault.azure.net/' --output json |
+                    ConvertFrom-Json).accessToken
+            } catch {
+                throw "Failed to get access token from Azure CLI: $_"
+            }
+        } elseif ($azPs) {
+            try {
+                $tokenResult = Get-AzAccessToken -ResourceUrl 'https://vault.azure.net/'
+                $accessToken = if ($tokenResult.Token -is [securestring]) {
+                    $tokenResult.Token | ConvertFrom-SecureString -AsPlainText
+                } else {
+                    [string]$tokenResult.Token
+                }
+            } catch {
+                throw "Failed to get access token from Az PowerShell: $_"
+            }
+        } else {
+            throw 'Azure authentication is required. Install and sign in with Azure CLI or Az PowerShell.'
+        }
+
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hashBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Jwt.SigningInput()))
+        } finally {
+            $sha256.Dispose()
+        }
+        $hash64url = [JwtBase64Url]::Encode($hashBytes)
+
+        $url = $KeyVaultKeyReference.TrimEnd('/') + '/sign?api-version=7.4'
+        $secureToken = ConvertTo-SecureString -String $accessToken -AsPlainText -Force
+
+        $params = @{
+            Method         = 'POST'
+            Uri            = $url
+            Body           = (@{ alg = 'RS256'; value = $hash64url } | ConvertTo-Json -Compress)
+            ContentType    = 'application/json'
+            Authentication = 'Bearer'
+            Token          = $secureToken
+        }
+
+        $result = Invoke-RestMethod @params
+        $Jwt.Signature = [string]$result.value
+        return $Jwt
+    }
+}

--- a/src/functions/private/Add-JwtLocalSignature.ps1
+++ b/src/functions/private/Add-JwtLocalSignature.ps1
@@ -1,0 +1,56 @@
+﻿function Add-JwtLocalSignature {
+    <#
+        .SYNOPSIS
+        Signs a JWT using a local RSA private key (RS256).
+
+        .DESCRIPTION
+        Takes an unsigned [Jwt] object, computes an RS256 signature over its signing input
+        (header.payload) using the supplied PEM-encoded RSA private key, and returns the same
+        [Jwt] object with the Signature property populated.
+
+        .EXAMPLE
+        ```powershell
+        Add-JwtLocalSignature -Jwt $unsigned -PrivateKey (Get-Content key.pem -Raw)
+        ```
+
+        Signs the unsigned JWT with the PEM-encoded RSA private key.
+
+        .OUTPUTS
+        Jwt
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Function mutates the in-memory [Jwt] object only'
+    )]
+    [CmdletBinding()]
+    [OutputType([Jwt])]
+    param(
+        # The unsigned [Jwt] object to sign.
+        [Parameter(Mandatory)]
+        [Jwt] $Jwt,
+
+        # The RSA private key in PEM format. Accepts a [string] or a [securestring].
+        [Parameter(Mandatory)]
+        [object] $PrivateKey
+    )
+
+    process {
+        if ($PrivateKey -is [securestring]) {
+            $PrivateKey = $PrivateKey | ConvertFrom-SecureString -AsPlainText
+        }
+
+        $rsa = [System.Security.Cryptography.RSA]::Create()
+        try {
+            $rsa.ImportFromPem([string]$PrivateKey)
+            $signatureBytes = $rsa.SignData(
+                [System.Text.Encoding]::UTF8.GetBytes($Jwt.SigningInput()),
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+            )
+            $Jwt.Signature = [JwtBase64Url]::Encode($signatureBytes)
+            return $Jwt
+        } finally {
+            if ($rsa) { $rsa.Dispose() }
+        }
+    }
+}

--- a/src/functions/private/New-JwtUnsigned.ps1
+++ b/src/functions/private/New-JwtUnsigned.ps1
@@ -1,0 +1,41 @@
+﻿function New-JwtUnsigned {
+    <#
+        .SYNOPSIS
+        Builds an unsigned JWT (header.payload) from a header and a payload.
+
+        .DESCRIPTION
+        Composes a [Jwt] object whose Signature property is empty. The encoded header and payload are
+        ready to be signed by Add-JwtLocalSignature or Add-JwtKeyVaultSignature.
+
+        .EXAMPLE
+        ```powershell
+        New-JwtUnsigned -Header @{ alg = 'RS256'; typ = 'JWT' } -Payload @{ iss = 'app'; iat = 1700000000; exp = 1700003600 }
+        ```
+
+        Returns a [Jwt] object with no signature.
+
+        .OUTPUTS
+        Jwt
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Function builds an in-memory object without modifying system state'
+    )]
+    [CmdletBinding()]
+    [OutputType([Jwt])]
+    param(
+        # The JWT header (alg, typ, kid, plus any custom fields).
+        [Parameter(Mandatory)]
+        [hashtable] $Header,
+
+        # The JWT payload / claims (iss, sub, aud, exp, nbf, iat, jti, plus any custom claims).
+        [Parameter(Mandatory)]
+        [hashtable] $Payload
+    )
+
+    process {
+        $jwtHeader = [JwtHeader]::new($Header)
+        $jwtPayload = [JwtPayload]::new($Payload)
+        return [Jwt]::new($jwtHeader, $jwtPayload)
+    }
+}

--- a/src/functions/public/New-Jwt.ps1
+++ b/src/functions/public/New-Jwt.ps1
@@ -1,31 +1,77 @@
 ﻿function New-Jwt {
     <#
         .SYNOPSIS
-        Creates a new JSON Web Token (JWT).
+        Creates and signs a JSON Web Token (JWT).
 
         .DESCRIPTION
-        Creates a new JSON Web Token (JWT). This is a placeholder function for the Jwt module.
+        Builds a JWT from a payload (and optional header overrides) and signs it using either a
+        local RSA private key or an Azure Key Vault key. Returns a strongly typed [Jwt] object;
+        call its ToString() method for the compact `header.payload.signature` form.
+
+        Only RS256 is supported in this release.
 
         .EXAMPLE
         ```powershell
-        New-Jwt
+        New-Jwt -Payload @{ iss = 'app'; iat = 1700000000; exp = 1700003600 } -PrivateKey (Get-Content key.pem -Raw)
         ```
 
-        Returns a placeholder string indicating that the function is not yet implemented.
+        Creates and signs a JWT with the given claims using a local RSA private key.
 
-        .NOTES
-        This function is a placeholder and will be replaced with the actual implementation.
+        .EXAMPLE
+        ```powershell
+        New-Jwt -Payload @{ iss = 'app'; iat = 1700000000; exp = 1700003600 } `
+            -KeyVaultKeyReference 'https://myvault.vault.azure.net/keys/mykey'
+        ```
+
+        Creates and signs a JWT using an Azure Key Vault key. Requires Azure CLI or Az PowerShell
+        to be installed and authenticated.
+
+        .OUTPUTS
+        Jwt
     #>
-    [CmdletBinding(SupportsShouldProcess)]
-    param()
+    [CmdletBinding(DefaultParameterSetName = 'LocalKey', SupportsShouldProcess)]
+    [OutputType([Jwt])]
+    param(
+        # Optional header overrides. `alg` and `typ` are set automatically; pass `kid` or any
+        # other JOSE header parameter here.
+        [Parameter()]
+        [hashtable] $Header,
 
-    begin {}
+        # The JWT payload / claims. Common registered claims (`iss`, `sub`, `aud`, `exp`, `nbf`,
+        # `iat`, `jti`) are recognized; everything else flows through as private claims.
+        [Parameter(Mandatory)]
+        [hashtable] $Payload,
+
+        # The RSA private key in PEM format. Accepts a [string] or a [securestring].
+        [Parameter(Mandatory, ParameterSetName = 'LocalKey')]
+        [object] $PrivateKey,
+
+        # The Azure Key Vault key URL used for signing
+        # (e.g. https://myvault.vault.azure.net/keys/mykey).
+        [Parameter(Mandatory, ParameterSetName = 'KeyVault')]
+        [string] $KeyVaultKeyReference,
+
+        # The signing algorithm. RS256 is the only supported value in this release.
+        [Parameter()]
+        [ValidateSet('RS256')]
+        [string] $Algorithm = 'RS256'
+    )
 
     process {
-        if ($PSCmdlet.ShouldProcess('Creating a new JWT')) {
-            Write-Warning 'New-Jwt is not yet implemented.'
+        $headerData = @{ alg = $Algorithm; typ = 'JWT' }
+        if ($Header) {
+            foreach ($key in $Header.Keys) {
+                $headerData[$key] = $Header[$key]
+            }
+        }
+
+        if (-not $PSCmdlet.ShouldProcess('JWT', 'Create and sign')) { return }
+
+        $unsigned = New-JwtUnsigned -Header $headerData -Payload $Payload
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'LocalKey' { return Add-JwtLocalSignature -Jwt $unsigned -PrivateKey $PrivateKey }
+            'KeyVault' { return Add-JwtKeyVaultSignature -Jwt $unsigned -KeyVaultKeyReference $KeyVaultKeyReference }
         }
     }
-
-    end {}
 }

--- a/tests/Jwt.Tests.ps1
+++ b/tests/Jwt.Tests.ps1
@@ -2,11 +2,107 @@
     'PSUseDeclaredVarsMoreThanAssignments', '',
     Justification = 'Required for Pester tests'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Tests construct in-memory key material'
+)]
 [CmdletBinding()]
 param()
 
 Describe 'Jwt' {
-    It 'New-Jwt should emit a warning that it is not yet implemented' {
-        New-Jwt 3>&1 | Should -BeLike '*not yet implemented*'
+    BeforeAll {
+        $script:rsa = [System.Security.Cryptography.RSA]::Create(2048)
+        $script:privatePem = $script:rsa.ExportRSAPrivateKeyPem()
+    }
+
+    AfterAll {
+        if ($script:rsa) { $script:rsa.Dispose() }
+    }
+
+    Context 'JwtBase64Url' {
+        It 'strips padding and replaces +/ with -_' {
+            $encoded = [JwtBase64Url]::ConvertToBase64UrlFormat('ab+/cd==')
+            $encoded | Should -Be 'ab-_cd'
+        }
+
+        It 'encodes a hashtable as URL-safe Base64 JSON' {
+            $encoded = [JwtBase64Url]::Encode(@{ a = 1 })
+            $encoded | Should -Be 'eyJhIjoxfQ'
+        }
+
+        It 'encodes a string as URL-safe Base64 UTF-8' {
+            [JwtBase64Url]::Encode('hi') | Should -Be 'aGk'
+        }
+    }
+
+    Context 'Jwt class' {
+        It 'ToString() returns header.payload.signature' {
+            $h = [JwtHeader]::new(@{ alg = 'RS256'; typ = 'JWT' })
+            $p = [JwtPayload]::new(@{ iss = 'tester' })
+            $jwt = [Jwt]::new($h, $p, 'sig')
+            $jwt.ToString() | Should -Match '^[^.]+\.[^.]+\.sig$'
+        }
+
+        It 'preserves header field order (alg, typ, kid)' {
+            $h = [JwtHeader]::new(@{ alg = 'RS256'; kid = 'k1' })
+            $ordered = $h.ToOrderedDictionary()
+            $keys = @($ordered.Keys)
+            $keys[0] | Should -Be 'alg'
+            $keys[1] | Should -Be 'typ'
+            $keys[2] | Should -Be 'kid'
+        }
+    }
+
+    Context 'New-Jwt with local RSA' {
+        It 'returns a [Jwt] object' {
+            $jwt = New-Jwt -Payload @{ iss = 'tester' } -PrivateKey $script:privatePem
+            $jwt | Should -BeOfType [Jwt]
+        }
+
+        It 'produces a token with three Base64URL segments' {
+            $jwt = New-Jwt -Payload @{ iss = 'tester' } -PrivateKey $script:privatePem
+            $parts = $jwt.ToString().Split('.')
+            $parts.Count | Should -Be 3
+            $parts | ForEach-Object { $_ | Should -Not -BeNullOrEmpty }
+        }
+
+        It 'produces an RS256 signature that verifies with the public key' {
+            $jwt = New-Jwt -Payload @{ iss = 'tester'; iat = 1700000000 } -PrivateKey $script:privatePem
+            $parts = $jwt.ToString().Split('.')
+            $signingInput = "$($parts[0]).$($parts[1])"
+
+            $sigSegment = $parts[2].Replace('-', '+').Replace('_', '/')
+            $padding = (4 - ($sigSegment.Length % 4)) % 4
+            $sigBytes = [System.Convert]::FromBase64String($sigSegment + ('=' * $padding))
+
+            $verified = $script:rsa.VerifyData(
+                [System.Text.Encoding]::UTF8.GetBytes($signingInput),
+                $sigBytes,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+            )
+            $verified | Should -BeTrue
+        }
+
+        It 'merges custom header fields and keeps alg from -Algorithm' {
+            $jwt = New-Jwt -Header @{ kid = 'key-1' } -Payload @{ iss = 'tester' } -PrivateKey $script:privatePem
+            $jwt.Header.kid | Should -Be 'key-1'
+            $jwt.Header.alg | Should -Be 'RS256'
+        }
+
+        It 'accepts a [securestring] private key' {
+            $secure = ConvertTo-SecureString -String $script:privatePem -AsPlainText -Force
+            $jwt = New-Jwt -Payload @{ iss = 'tester' } -PrivateKey $secure
+            $jwt | Should -BeOfType [Jwt]
+        }
+
+        It 'recognizes registered claims on the payload' {
+            $jwt = New-Jwt -Payload @{ iss = 'tester'; sub = 'subj'; exp = 1700003600; iat = 1700000000 } `
+                -PrivateKey $script:privatePem
+            $jwt.Payload.iss | Should -Be 'tester'
+            $jwt.Payload.sub | Should -Be 'subj'
+            $jwt.Payload.exp | Should -Be 1700003600
+            $jwt.Payload.iat | Should -Be 1700000000
+        }
     }
 }


### PR DESCRIPTION
`New-Jwt` now creates and signs real JSON Web Tokens. The placeholder is replaced by an RS256 signing implementation backed by either a local RSA private key or an Azure Key Vault key, and the JOSE primitives (`Jwt`, `JwtHeader`, `JwtPayload`, `JwtBase64Url`) are available as typed PowerShell classes. The module can now be consumed independently by automation that previously had to depend on the `GitHub` module just to mint a JWT.

- Fixes #3

## New: Create signed JWTs with `New-Jwt`

`New-Jwt` returns a `[Jwt]` object whose `ToString()` produces the compact `header.payload.signature` form. The `-Algorithm` parameter currently accepts `RS256` only; additional algorithms are tracked in follow-up issues.

Sign with a local PEM-encoded RSA private key:

```powershell
$now = [System.DateTimeOffset]::UtcNow
$jwt = New-Jwt `
    -Header  @{ kid = 'my-key-id' } `
    -Payload @{
        iss = 'my-app'
        iat = $now.ToUnixTimeSeconds()
        exp = $now.AddMinutes(10).ToUnixTimeSeconds()
    } `
    -PrivateKey (Get-Content ./private-key.pem -Raw)

$jwt.ToString()  # header.payload.signature
```

`-PrivateKey` accepts either a `[string]` or a `[securestring]`.

Sign with Azure Key Vault:

```powershell
$jwt = New-Jwt `
    -Payload @{ iss = 'my-app'; iat = $iat; exp = $exp } `
    -KeyVaultKeyReference 'https://myvault.vault.azure.net/keys/my-key'
```

Key Vault signing calls the [Sign REST API](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/sign/sign) (`api-version=7.4`) and obtains a bearer token from Azure CLI or Az PowerShell at call time. Neither is a declared module dependency — install and sign in with one of them before calling.

## New: Typed JOSE classes

The token and its parts are first-class PowerShell types so they can be inspected, composed, and round-tripped without string-juggling.

| Class          | Purpose                                                                          |
| -------------- | -------------------------------------------------------------------------------- |
| `Jwt`          | Token object with `Header`, `Payload`, `Signature`, `EncodedHeader`, `EncodedPayload`. `ToString()` returns the compact form. |
| `JwtHeader`    | Typed JOSE header (`alg`, `typ`, `kid`, plus an `AdditionalFields` extension bag).      |
| `JwtPayload`   | Typed payload (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`, plus `AdditionalFields`).|
| `JwtBase64Url` | Static Base64URL encoding utilities per [RFC 4648 §5](https://datatracker.ietf.org/doc/html/rfc4648#section-5). |

## Changed: Module is now usable

The README's "not yet implemented" note is removed and replaced with usage documentation covering both signing methods and the public surface table.

## Technical Details

- New classes in `src/classes/public/`: `JwtBase64Url`, `JwtHeader`, `JwtPayload`, `Jwt`. `Jwt` declares `Header`/`Payload` as `[object]` rather than the concrete sibling-class types so each `.ps1` can be parsed independently in dev/test (the PSModule build concatenates them into one `.psm1` where typed cross-references would also work). Constructors still type-check the inputs.
- New private functions in `src/functions/private/`: `New-JwtUnsigned` (composes the unsigned `[Jwt]`), `Add-JwtLocalSignature` (RS256 via `[System.Security.Cryptography.RSA]::Create()` + `ImportFromPem` + PKCS#1 v1.5 padding), `Add-JwtKeyVaultSignature` (SHA-256 digest + Key Vault Sign REST call). The Key Vault helper detects Azure CLI (`az`) or Az PowerShell (`Get-AzAccessToken`) at call time and throws a clear error when neither is available — matching the behavior of the equivalent helper in the `GitHub` module.
- `New-Jwt` uses two parameter sets (`LocalKey`, `KeyVault`), defaults to `LocalKey`, and supports `ShouldProcess`. `-Algorithm` is `[ValidateSet('RS256')]` for forward compatibility.
- JSON serialization uses `[ordered]` dictionaries so `alg`/`typ`/`kid` and the registered claims are emitted in a deterministic order; signatures over the same input are reproducible.
- Pester tests in `tests/Jwt.Tests.ps1` cover Base64URL encoding, `[Jwt].ToString()` shape, header field ordering, RS256 signature verification with an ephemeral key pair, custom header merging, `[securestring]` key acceptance, and registered-claim recognition. All 11 tests pass locally.
- Implementation plan progress for #3:
  - [x] Skeleton cleanup (already on `main` from prior commits)
  - [x] `JwtBase64Url`, `JwtHeader`, `JwtPayload`, `Jwt` classes
  - [x] `New-Jwt`, `New-JwtUnsigned`, `Add-JwtLocalSignature`, `Add-JwtKeyVaultSignature`
  - [x] Update root `README.md`
  - [x] Create `tests/Jwt.Tests.ps1`
  - [ ] Update `src/manifest.psd1` and `src/README.md` — n/a, those files were removed in earlier cleanup and are generated by the PSModule framework.
- Issue #13 (parsing, validation, JWK) explicitly depends on the classes added here and will land as a follow-up PR to keep this changeset focused and reviewable.