### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jwt
 
-Jwt is a PowerShell module for working with JSON Web Tokens.
+Jwt is a PowerShell module for creating, decoding, and verifying JSON Web Tokens (JWTs). It supports HS256
+shared-secret tokens, RS256 certificate-signed tokens, and the `none` algorithm.
 
 ## Installation
 
@@ -11,6 +12,24 @@ Install-PSResource -Name Jwt
 Import-Module -Name Jwt
 ```
 
+## Usage
+
+### Example: Create and validate an HMAC-signed token
+
+```powershell
+$payload = '{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022}'
+$secret = 'a-string-secret-at-least-256-bits-long'
+
+$jwt = New-Jwt -Header '{"alg":"HS256","typ":"JWT"}' -PayloadJson $payload -Secret $secret
+$jwt | Test-Jwt -Secret $secret
+```
+
+### Example: Decode the payload of an existing token
+
+```powershell
+$jwt | Get-JwtPayload
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/Jwt](https://psmodule.io/Jwt/).
@@ -19,9 +38,5 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Jwt
-Get-Help <CommandName> -Examples
+Get-Help -Name New-Jwt -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Jwt is a PowerShell module for creating, decoding, and verifying JSON Web Tokens (JWTs). It supports HS256
 shared-secret tokens, RS256 certificate-signed tokens, and the `none` algorithm.
 
+> [!WARNING]
+> The `none` algorithm produces an unsigned token whose integrity cannot be verified. Avoid it for
+> authentication or authorization; use HS256 or RS256 for any token that must be trusted.
+
 ## Installation
 
 Install the module from the PowerShell Gallery:

--- a/README.md
+++ b/README.md
@@ -1,70 +1,27 @@
 # Jwt
 
-`Jwt` is a PowerShell module for creating and verifying JSON Web Tokens. This repository maintains the current `Jwt` module command surface under PSModule maintenance so existing users can continue to install and use the package from PowerShell Gallery.
+Jwt is a PowerShell module for working with JSON Web Tokens.
 
 ## Installation
+
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name Jwt
 Import-Module -Name Jwt
 ```
 
-## Commands
+## Documentation
 
-The maintained module exports the same JWT commands and alias used by the current package:
+Documentation is published at [psmodule.io/Jwt](https://psmodule.io/Jwt/).
 
-```powershell
-ConvertFrom-Base64UrlString
-ConvertTo-Base64UrlString
-Get-JwtHeader
-Get-JwtPayload
-New-Jwt
-Test-Jwt
-Verify-JwtSignature
-```
-
-## Usage
-
-Create and validate an HMAC-signed JWT:
-
-```powershell
-$header = '{"alg":"HS256","typ":"JWT"}'
-$payload = '{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022}'
-$secret = 'a-string-secret-at-least-256-bits-long'
-
-$jwt = New-Jwt -Header $header -PayloadJson $payload -Secret $secret
-Test-Jwt -jwt $jwt -Secret $secret
-```
-
-Read the header and payload from an existing token:
-
-```powershell
-Get-JwtHeader -jwt $jwt
-Get-JwtPayload -jwt $jwt
-```
-
-For more information about each command, use PowerShell help:
+Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Jwt
-Get-Help New-Jwt -Full
+Get-Help <CommandName> -Examples
 ```
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
The `Jwt` README is now a concise landing page. Users get a short overview, one-line install, a
copy-paste **Usage** showcase using the real commands, and links to the published docs — instead of an
exhaustive command inventory that duplicated generated help.

## What changed

- **Usage showcase** — realistic examples for `New-Jwt` → `Test-Jwt` → `Get-JwtPayload` (create an
  HS256 token, validate it, decode the payload).
- **Security note** — a caution that the `none` algorithm produces an unsigned token and should not be
  used for authentication or authorization.
- **Documentation** — points to [psmodule.io/Jwt](https://psmodule.io/Jwt/) plus a real discovery
  snippet (`Get-Command -Module Jwt`, `Get-Help -Name New-Jwt -Examples`).
- **Removed** the redundant `## Commands` inventory (duplicated generated help) and the
  `## Contributing` section.

## Technical details

- Updates `README.md` only.
- Aligns the README with the PSModule module landing-page standard.
