### PR TITLE
test: expand Jwt test suite to production-level coverage

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@fb1bdb8fefd243292f779d2a856a38db6fe6daf4 # v6.1.13
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@688896dc3ef70fb35bd74ae5328e76d5e57fe08a # v6.1.15
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-

--- a/src/functions/public/Keys/New-JwtSigningKey.ps1
+++ b/src/functions/public/Keys/New-JwtSigningKey.ps1
@@ -86,7 +86,7 @@ function New-JwtSigningKey {
                 }
                 $bytes = [byte[]]::new($keyLength)
                 [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
-                $key = $bytes
+                return , $bytes
             }
             '^(RS|PS)' {
                 $rsa = [System.Security.Cryptography.RSA]::Create()

--- a/tests/Integration.Jwt.Tests.ps1
+++ b/tests/Integration.Jwt.Tests.ps1
@@ -671,5 +671,81 @@ Describe 'Jwt module' {
             }
         }
     }
+
+    Context 'Production-level edge cases' {
+        BeforeAll {
+            $script:secret = 'a-string-secret-at-least-256-bits-long'
+            $script:goodJwt = New-Jwt -Payload @{ sub = 'joe' } -Algorithm HS256 -Key $script:secret
+        }
+
+        It 'Test-Jwt -Detailed reports the failed check when the signature is invalid' {
+            $compact = $script:goodJwt.ToString()
+            $parts = $compact.Split('.')
+            $parts[2] = ConvertTo-Base64UrlString ([byte[]](1..32))
+            $tampered = $parts -join '.'
+            $result = Test-Jwt -Token $tampered -Key $script:secret -RequireExpiration $false -Detailed
+
+            $result.Valid | Should -BeFalse
+            $result.SignatureValidated | Should -BeFalse
+            ($result.Checks | Where-Object Name -EQ 'Signature').Passed | Should -BeFalse
+        }
+
+        It 'Test-Jwt -Detailed reports the failed claim check' {
+            $nowSec = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+            $expired = New-Jwt -Payload @{ sub = 'joe'; exp = $nowSec - 60 } -Algorithm HS256 -Key $script:secret
+            $result = Test-Jwt -Token $expired -Key $script:secret -Detailed
+
+            $result.Valid | Should -BeFalse
+            ($result.Checks | Where-Object Name -EQ 'Expiration').Passed | Should -BeFalse
+        }
+
+        It 'New-Jwt -GenerateKey produces valid tokens for all algorithm families' -ForEach @(
+            @{ Alg = 'HS256' },
+            @{ Alg = 'RS256' },
+            @{ Alg = 'ES256' }
+        ) {
+            $jwt = New-Jwt -Payload @{ sub = 'joe' } -Algorithm $Alg -GenerateKey
+
+            $jwt | Should -BeOfType [Jwt]
+            $jwt.Header.alg | Should -Be $Alg
+            $jwt.ToString().Split('.').Count | Should -Be 3
+            $jwt.Signature | Should -Not -BeNullOrEmpty
+        }
+
+        It 'ConvertFrom-Jwt accepts a SecureString token' {
+            $compact = $script:goodJwt.ToString()
+            $secure = ConvertTo-SecureString $compact -AsPlainText -Force
+            $parsed = ConvertFrom-Jwt -Token $secure
+
+            $parsed.Payload.sub | Should -Be 'joe'
+        }
+
+        It 'Test-Jwt returns false when the signature segment is empty for a signed algorithm' {
+            $compact = $script:goodJwt.ToString()
+            $parts = $compact.Split('.')
+            $emptySig = "$($parts[0]).$($parts[1])."
+
+            Test-Jwt -Token $emptySig -Key $script:secret -RequireExpiration $false | Should -BeFalse
+        }
+
+        It 'New-Jwt parameter validation rejects a non-hashtable payload' {
+            { New-Jwt -Payload 'not-a-hashtable' -Algorithm HS256 -Key $script:secret } |
+                Should -Throw
+        }
+
+        It 'Test-Jwt parameter validation rejects a null token' {
+            { Test-Jwt -Token $null -Key $script:secret -RequireExpiration $false } | Should -Throw
+        }
+
+        It 'Verbose output does not include the payload or key material' {
+            $payload = @{ sub = 'joe'; secret = 'do-not-leak' }
+            $verbose = & { New-Jwt -Payload $payload -Algorithm HS256 -Key $script:secret -Verbose } 4>&1 |
+                Where-Object { $_.GetType().Name -eq 'VerboseRecord' } |
+                Out-String
+
+            $verbose | Should -Not -Match 'do-not-leak'
+            $verbose | Should -Not -Match ([regex]::Escape($script:secret))
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary

Targets `feat/13-implement-jwt-module` and adds production-level edge-case coverage to the JWT v2 integration suite. While adding tests, it also fixes a regression where `New-JwtSigningKey -Algorithm HS*` returned `[object[]]` instead of `[byte[]]`, breaking `New-Jwt -GenerateKey` for HMAC algorithms.

## What changed

### Tests (`tests/Integration.Jwt.Tests.ps1`)

Added a new `Production-level edge cases` context covering:

- `Test-Jwt -Detailed` reports failed signature and failed claim checks.
- `New-Jwt -GenerateKey` produces valid tokens for HS256, RS256, and ES256.
- `ConvertFrom-Jwt` accepts a `SecureString` token.
- `Test-Jwt` returns `$false` for an empty signature segment on signed algorithms.
- `New-Jwt` parameter validation rejects non-hashtable payloads.
- `Test-Jwt` parameter validation rejects `$null` tokens.
- Verbose output does not leak payload secrets or key material.

### Bug fix (`src/functions/public/Keys/New-JwtSigningKey.ps1`)

PowerShell unwraps `[byte[]]` to `[object[]]` when returned through an untyped variable. The HS* branch now returns `,$bytes` so the byte-array type is preserved, allowing `New-Jwt -Algorithm HS256 -GenerateKey` to sign and verify correctly.

### CI

Bumped the reusable workflow pin to Process-PSModule v6.1.15 while preserving the explicit `TestData` mapping required by the reusable workflow's secrets interface.

## Verification

```powershell
Import-Module Pester -RequiredVersion 6.0.1 -Force
$config = New-PesterConfiguration
$config.Run.Path = 'tests'
Invoke-Pester -Configuration $config
```

Result: **123 passed, 0 failed** (1 skipped: optional Azure Key Vault test).

## Related

Contributes to #26 (JWT v2 overhaul).

---

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>